### PR TITLE
Fix typos in docs/code/comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SBN Client
 
 The Software Bus Network Client (SBNC) communicates with NASA's core Flight System (cFS) Software Bus Network (SBN) application.
-Its main purpose it to facilitate two-way communication from the cFS Software Bus service to an external application (i.e. an application that is not a child task of cFS).
+Its main purpose is to facilitate two-way communication from the cFS Software Bus service to an external application (i.e. an application that is not a child task of cFS).
 SBNC implements the SBN communication protocol and provides access to the Software Bus through a standalone C library.
 
 We also support using SBNC within existing cFS applications through a modified build system and function wrappers.

--- a/fsw/public_inc/sbn_client_init.h
+++ b/fsw/public_inc/sbn_client_init.h
@@ -18,7 +18,7 @@
 **
 ** Purpose:
 **      This header file contains the definition of the cFS sbn_client app's 
-**      initialzation function.  The init function must be called by a cFS
+**      initialization function.  The init function must be called by a cFS
 **      multi-process app in order to use the features of cFE that sbn_client
 **      provides.
 **
@@ -27,7 +27,7 @@
 ******************************************************************************/
 /****************** Function Prototypes **********************/
 
-/** @defgroup SBNCLIENTAPIInitilization sbn_client Init API
+/** @defgroup SBNCLIENTAPIInitialization sbn_client Init API
  * @{
  */
 

--- a/fsw/src/sbn_client_ingest.h
+++ b/fsw/src/sbn_client_ingest.h
@@ -19,7 +19,7 @@
 
 /**
  * Extern reference to sbn client pipe table.
- * Allows the message injest to fill the pipe
+ * Allows the message ingest to fill the pipe
  */
 extern CFE_SBN_Client_PipeD_t PipeTbl[CFE_PLATFORM_SBN_CLIENT_MAX_PIPES];
  

--- a/fsw/src/sbn_client_minders.c
+++ b/fsw/src/sbn_client_minders.c
@@ -54,7 +54,7 @@ void *SBN_Client_ReceiveMinder(void *vargp)
         
         if (status != CFE_SUCCESS)
         {
-            log_message("Recieve message returned error 0x%08X\n", status);
+            log_message("Receive message returned error 0x%08X\n", status);
             consec_error_count++;
         }
         else

--- a/fsw/src/sbn_client_utils.c
+++ b/fsw/src/sbn_client_utils.c
@@ -115,7 +115,7 @@ void invalidate_pipe(CFE_SBN_Client_PipeD_t *pipe)
     /* SB always holds one message so Number of messages should always be a minimum of 1 */
     pipe->NumberOfMessages = 1;
     /* Message to be read will be incremented after receive is called */
-    /* Therefor initial next message is the last in the chain */
+    /* Therefore initial next message is the last in the chain */
     pipe->ReadMessage = CFE_PLATFORM_SBN_CLIENT_MAX_PIPE_DEPTH - 1;
     memset(&pipe->PipeName[0],0,OS_MAX_API_NAME);
     

--- a/unit-test/helpers/sbn_client_wrapped_functions.c
+++ b/unit-test/helpers/sbn_client_wrapped_functions.c
@@ -358,7 +358,7 @@ void __wrap_perror(const char *str)
     if (strlen(perror_expected_string) > 0)
     {
         UtAssert_StrCmp(str, perror_expected_string, 
-          TestResultMsg("perror expected string '%s' == '%s' string recieved",
+          TestResultMsg("perror expected string '%s' == '%s' string received",
           perror_expected_string, str));
     }
     

--- a/unit-test/sbn_client_minders_tests.c
+++ b/unit-test/sbn_client_minders_tests.c
@@ -110,7 +110,7 @@ void Test_SBN_Client_ReceiveMinder_Outlog_messageError(void)
     use_wrap_recv_msg = TRUE;
     
     wrap_recv_msg_return_value = Any_int32_Except(CFE_SUCCESS);
-    snprintf(err_msg, 50, "Recieve message returned error 0x%08X\n", 
+    snprintf(err_msg, 50, "Receive message returned error 0x%08X\n", 
       wrap_recv_msg_return_value);
     
     log_message_expected_string = err_msg;

--- a/unit-test/sbn_client_wrappers_tests.c
+++ b/unit-test/sbn_client_wrappers_tests.c
@@ -452,7 +452,7 @@ void Test__wrap_CFE_SB_RcvMsg_SuccessPollRequestHasMessageInPipe(void)
     UtAssert_MemCmp(buffer, msg, msgSize, "Message in buffer is as expected");    
     UtAssert_True(
       PipeTbl[pipe_assigned].NumberOfMessages == number_of_messages - 1, 
-      "PipeTbl[%d].NumberOfMessages should have decresed by 1 to %d and is %d", 
+      "PipeTbl[%d].NumberOfMessages should have decreased by 1 to %d and is %d", 
       pipe_assigned, number_of_messages - 1, 
       PipeTbl[pipe_assigned].NumberOfMessages);
     UtAssert_True(PipeTbl[pipe_assigned].ReadMessage == current_read_msg, 
@@ -503,7 +503,7 @@ void Test__wrap_CFE_SB_RcvMsg_SuccessTimeoutPendMessageAlreadyInPipe(void)
     UtAssert_MemCmp(buffer, msg, msgSize, "Message in buffer is as expected"); 
     UtAssert_True(
       PipeTbl[pipe_assigned].NumberOfMessages == number_of_messages - 1, 
-      "PipeTbl[%d].NumberOfMessages should have decresed by 1 to %d and is %d", 
+      "PipeTbl[%d].NumberOfMessages should have decreased by 1 to %d and is %d", 
       pipe_assigned, number_of_messages - 1, 
       PipeTbl[pipe_assigned].NumberOfMessages);
     UtAssert_True(
@@ -555,7 +555,7 @@ void Test__wrap_CFE_SB_RcvMsg_SuccessTimeoutValueMessageAlreadyInPipe(void)
     UtAssert_MemCmp(buffer, msg, msgSize, "Message in buffer is as expected"); 
     UtAssert_True(
       PipeTbl[pipe_assigned].NumberOfMessages == number_of_messages - 1, 
-      "PipeTbl[%d].NumberOfMessages should have decresed by 1 to %d and is %d", 
+      "PipeTbl[%d].NumberOfMessages should have decreased by 1 to %d and is %d", 
       pipe_assigned, number_of_messages - 1, 
       PipeTbl[pipe_assigned].NumberOfMessages);
     UtAssert_True(PipeTbl[pipe_assigned].ReadMessage == current_read_msg, 
@@ -715,7 +715,7 @@ void Test__wrap_CFE_SB_RcvMsg_FailsPthreadMutexUnlockFailure(void)
     UtAssert_True(buffer == NULL, "Buffer returned points to NULL");    
     UtAssert_True(
       PipeTbl[pipe_assigned].NumberOfMessages == number_of_messages - 1, 
-      "PipeTbl[%d].NumberOfMessages should have decresed by 1 to %d and is %d", 
+      "PipeTbl[%d].NumberOfMessages should have decreased by 1 to %d and is %d", 
       pipe_assigned, number_of_messages - 1, 
       PipeTbl[pipe_assigned].NumberOfMessages);
     UtAssert_True(PipeTbl[pipe_assigned].ReadMessage == current_read_msg, 
@@ -776,7 +776,7 @@ void Test__wrap_CFE_SB_RcvMsg_SuccessPipeIsFull(void)
         ((unsigned char *)buffer)[i]);
     }
     UtAssert_True(PipeTbl[pipe_assigned].NumberOfMessages == num_msg - 1, 
-      "PipeTbl[%d].NumberOfMessages should have decresed by 1 to %d and is %d", 
+      "PipeTbl[%d].NumberOfMessages should have decreased by 1 to %d and is %d", 
       pipe_assigned, num_msg - 1, PipeTbl[pipe_assigned].NumberOfMessages);
     UtAssert_True(PipeTbl[pipe_assigned].ReadMessage == current_read_msg, 
       "PipeTbl[%d].ReadMessage should have progressed to %d from %d and is %d", 

--- a/unit-test/stubs/sbn_client_logger_stubs.c
+++ b/unit-test/stubs/sbn_client_logger_stubs.c
@@ -27,7 +27,7 @@ int32 log_message(const char *format, ...)
     // if (strlen(log_message_expected_string) > 0)
     // {
     //     UtAssert_StrCmp(str, log_message_expected_string, 
-    //       TestResultMsg("log_message expected string '%s' == '%s' string recieved",
+    //       TestResultMsg("log_message expected string '%s' == '%s' string received",
     //       log_message_expected_string, str));
     // }
     // 


### PR DESCRIPTION
Quick scrub of the files turned up a number of typos.

No code changes.