### PR TITLE
Fixes for reading bytes base on message size

### DIFF
--- a/fsw/src/sbn_client.c
+++ b/fsw/src/sbn_client.c
@@ -86,17 +86,17 @@ void SendSubToSbn(int SubType, CFE_SB_MsgId_t MsgID,
 int32 recv_msg(int32 sockfd)
 {
     unsigned char sbn_hdr_buffer[SBN_PACKED_HDR_SZ];
-    unsigned char msg[CFE_SB_MAX_SB_MSG_SIZE];
+    unsigned char msg[CFE_SBN_CLIENT_MAX_MESSAGE_SIZE];
     SBN_MsgSz_t MsgSz;
     SBN_MsgType_t MsgType;
     uint32 CpuID;
     
-    int status = CFE_SBN_CLIENT_ReadBytes(sockfd, sbn_hdr_buffer, 
+    int status = CFE_SBN_Client_ReadBytes(sockfd, sbn_hdr_buffer, 
                                           SBN_PACKED_HDR_SZ);
     
     if (status != CFE_SUCCESS)
     {
-        printf("SBN_CLIENT: recv_msg call to CFE_SBN_CLIENT_ReadBytes returned" 
+        printf("SBN_CLIENT: recv_msg call to CFE_SBN_Client_ReadBytes returned " 
                "status = %d\n", status);
     }
     else
@@ -112,23 +112,15 @@ int32 recv_msg(int32 sockfd)
         switch(MsgType)
         {
             case SBN_NO_MSG:
-                status = CFE_SBN_CLIENT_ReadBytes(sockfd, msg, MsgSz);
-                break;
             case SBN_SUB_MSG:
-                status = CFE_SBN_CLIENT_ReadBytes(sockfd, msg, MsgSz);
-                break;
             case SBN_UNSUB_MSG:
-                status = CFE_SBN_CLIENT_ReadBytes(sockfd, msg, MsgSz);
+            case SBN_PROTO_MSG:
+            case SBN_HEARTBEAT_MSG:
+                status = CFE_SBN_Client_ReadBytes(sockfd, msg, MsgSz);
                 break;
             case SBN_APP_MSG:
                 ingest_app_message(sockfd, MsgSz);
                 status = CFE_SUCCESS;
-                break;
-            case SBN_PROTO_MSG:      
-                status = CFE_SBN_CLIENT_ReadBytes(sockfd, msg, MsgSz);
-                break;
-            case SBN_HEARTBEAT_MSG:
-                status = CFE_SBN_CLIENT_ReadBytes(sockfd, msg, MsgSz);
                 break;
 
             default:

--- a/fsw/src/sbn_client_ingest.c
+++ b/fsw/src/sbn_client_ingest.c
@@ -28,17 +28,17 @@ void ingest_app_message(int SockFd, SBN_MsgSz_t MsgSz)
 {
     int            status, i;
     boolean        at_least_1_pipe_is_in_use = FALSE;    
-    unsigned char  msg_buffer[CFE_SB_MAX_SB_MSG_SIZE];
+    unsigned char  msg_buffer[CFE_SBN_CLIENT_MAX_MESSAGE_SIZE];
     CFE_SB_MsgId_t MsgId;
     
-    status = CFE_SBN_CLIENT_ReadBytes(SockFd, msg_buffer, MsgSz);
+    status = CFE_SBN_Client_ReadBytes(SockFd, msg_buffer, MsgSz);
     
     if (status != CFE_SUCCESS)
     {
         char error_message[61];
         
         snprintf(error_message, sizeof(error_message), 
-          "CFE_SBN_CLIENT_ReadBytes returned a bad status = 0x%08X\n", status);
+          "CFE_SBN_Client_ReadBytes returned a bad status = 0x%08X\n", status);
         log_message(error_message);
         
         return;

--- a/fsw/src/sbn_client_utils.c
+++ b/fsw/src/sbn_client_utils.c
@@ -66,11 +66,21 @@ int message_entry_point(CFE_SBN_Client_PipeD_t pipe)
         CFE_PLATFORM_SBN_CLIENT_MAX_PIPE_DEPTH;
 }
 
-int CFE_SBN_CLIENT_ReadBytes(int sockfd, unsigned char *msg_buffer, 
+int CFE_SBN_Client_ReadBytes(int sockfd, unsigned char *msg_buffer, 
                              size_t MsgSz)
 {
     int bytes_received = 0;
     int total_bytes_recd = 0;
+
+    if (MsgSz > CFE_SBN_CLIENT_MAX_MESSAGE_SIZE)
+    {
+
+        log_message(
+            "CFE_SBN_Client_ReadBytes: MsgSz (%u) > CFE_SBN_CLIENT_MAX_MESSAGE_SIZE (%u)",
+            MsgSz, CFE_SBN_CLIENT_MAX_MESSAGE_SIZE
+        );
+        return CFE_SBN_CLIENT_BAD_ARGUMENT;
+    }
     
     /* TODO:Some kind of timeout on this? */
     while (total_bytes_recd != MsgSz)
@@ -94,7 +104,7 @@ int CFE_SBN_CLIENT_ReadBytes(int sockfd, unsigned char *msg_buffer,
         total_bytes_recd += bytes_received;
     }
     // 
-    // log_message("CFE_SBN_CLIENT_ReadBytes THIS MESSAGE:");
+    // log_message("CFE_SBN_Client_ReadBytes THIS MESSAGE:");
     // int i =0;
     // for (i = 0; i < MsgSz; i++)
     // {

--- a/fsw/src/sbn_client_utils.h
+++ b/fsw/src/sbn_client_utils.h
@@ -80,7 +80,7 @@ typedef struct {
 
 int32 check_pthread_create_status(int, int32);
 int message_entry_point(CFE_SBN_Client_PipeD_t);
-int CFE_SBN_CLIENT_ReadBytes(int, unsigned char *, size_t);
+int CFE_SBN_Client_ReadBytes(int, unsigned char *, size_t);
 void invalidate_pipe(CFE_SBN_Client_PipeD_t *);
 size_t write_message(int, char *, size_t);
 uint8 CFE_SBN_Client_GetPipeIdx(CFE_SB_PipeId_t);

--- a/fsw/src/sbn_client_wrappers.c
+++ b/fsw/src/sbn_client_wrappers.c
@@ -198,7 +198,7 @@ uint32 __wrap_CFE_SB_SendMsg(CFE_SB_Msg_t *msg)
     size_t write_result, total_size = msg_size + SBN_PACKED_HDR_SZ;
     Pack_t Pack;
 
-    if (total_size > CFE_SB_MAX_SB_MSG_SIZE)
+    if (total_size > CFE_SBN_CLIENT_MAX_MESSAGE_SIZE)
     {
         return CFE_SB_MSG_TOO_BIG;
     }

--- a/unit-test/CMakeLists.txt
+++ b/unit-test/CMakeLists.txt
@@ -60,7 +60,7 @@ set(WRAPS "${WRAPS},-wrap,CFE_SBN_Client_InitPipeTbl")
 set(WRAPS "${WRAPS},-wrap,check_pthread_create_status")
 set(WRAPS "${WRAPS},-wrap,send_heartbeat")
 set(WRAPS "${WRAPS},-wrap,recv_msg")
-set(WRAPS "${WRAPS},-wrap,CFE_SBN_CLIENT_ReadBytes")
+set(WRAPS "${WRAPS},-wrap,CFE_SBN_Client_ReadBytes")
 set(WRAPS "${WRAPS},-wrap,pthread_mutex_lock")
 set(WRAPS "${WRAPS},-wrap,pthread_mutex_unlock")
 set(WRAPS "${WRAPS},-wrap,pthread_cond_signal")
@@ -68,6 +68,7 @@ set(WRAPS "${WRAPS},-wrap,CFE_SBN_Client_GetMsgId")
 set(WRAPS "${WRAPS},-wrap,CFE_SBN_Client_GetPipeIdx")
 set(WRAPS "${WRAPS},-wrap,pthread_cond_timedwait")
 set(WRAPS "${WRAPS},-wrap,pthread_cond_wait")
+set(WRAPS "${WRAPS},-wrap,ingest_app_message")
 
 
 # Get the files in the source subdirectory

--- a/unit-test/helpers/sbn_client_wrapped_functions.c
+++ b/unit-test/helpers/sbn_client_wrapped_functions.c
@@ -114,7 +114,7 @@ int __wrap_CFE_SBN_Client_ReadBytes(int sockfd, unsigned char *msg_buffer,
             }
             else
             {
-                printf("ERR: __wrap_CFE_SBN_Client_ReadBytes was given MsgSz too large: %u\n", MsgSz);
+                printf("ERR: __wrap_CFE_SBN_Client_ReadBytes was given MsgSz too large: %zu\n", MsgSz);
             }
             result = -999999996;
         }

--- a/unit-test/helpers/sbn_client_wrapped_functions.c
+++ b/unit-test/helpers/sbn_client_wrapped_functions.c
@@ -15,10 +15,14 @@
 #define PTHREAD_MUTEX_UNLOCK_SUCCESS  0
 #define PTHREAD_MUTEX_UNLOCK_FAILURE  EPERM
 
-
-boolean use_wrap_CFE_SBN_CLIENT_ReadBytes = FALSE;
-unsigned char *wrap_CFE_SBN_CLIENT_ReadBytes_msg_buffer = NULL;
-int wrap_CFE_SBN_CLIENT_ReadBytes_return_value = INT_MIN;
+boolean use_wrap_ingest_app_message = FALSE;
+boolean wrap_ingest_app_message_was_called = FALSE;
+int wrap_ingest_app_message_call_count = 0;
+boolean use_wrap_CFE_SBN_Client_ReadBytes = FALSE;
+unsigned char *wrap_CFE_SBN_Client_ReadBytes_msg_buffer = NULL;
+int wrap_CFE_SBN_Client_ReadBytes_return_value = INT_MIN;
+boolean wrap_CFE_SBN_Client_ReadBytes_was_called = FALSE;
+int wrap_CFE_SBN_Client_ReadBytes_call_count = 0;
 boolean wrap_pthread_mutex_lock_should_be_called = FALSE;
 boolean wrap_pthread_mutex_lock_was_called = FALSE;
 int wrap_pthread_mutex_lock_return_value = 0;
@@ -75,23 +79,49 @@ void wrap_sleep_set_continue_heartbeat_false(void)
     continue_heartbeat = FALSE;
 }
 
+void __wrap_ingest_app_message(int SockFd, SBN_MsgSz_t MsgSz)
+{
+    wrap_ingest_app_message_was_called = TRUE;
+    wrap_ingest_app_message_call_count++;
 
-int __wrap_CFE_SBN_CLIENT_ReadBytes(int sockfd, unsigned char *msg_buffer, 
+    if (!use_wrap_ingest_app_message)
+    {
+        __real_ingest_app_message(SockFd, MsgSz);
+    }
+}
+
+
+int __wrap_CFE_SBN_Client_ReadBytes(int sockfd, unsigned char *msg_buffer, 
                                     size_t MsgSz)
 {
     int result;
     
-    if (use_wrap_CFE_SBN_CLIENT_ReadBytes)
+    wrap_CFE_SBN_Client_ReadBytes_was_called = TRUE;
+    wrap_CFE_SBN_Client_ReadBytes_call_count++;
+    
+    if (use_wrap_CFE_SBN_Client_ReadBytes)
     {
-        if (wrap_CFE_SBN_CLIENT_ReadBytes_msg_buffer != NULL)
+        if (wrap_CFE_SBN_Client_ReadBytes_msg_buffer != NULL && MsgSz <= CFE_SBN_CLIENT_MAX_MESSAGE_SIZE)
         {
-            memcpy(msg_buffer, wrap_CFE_SBN_CLIENT_ReadBytes_msg_buffer, MsgSz);
+            memcpy(msg_buffer, wrap_CFE_SBN_Client_ReadBytes_msg_buffer, MsgSz);
+            result = wrap_CFE_SBN_Client_ReadBytes_return_value;
         }
-        result = wrap_CFE_SBN_CLIENT_ReadBytes_return_value;
+        else
+        {   
+            if (wrap_CFE_SBN_Client_ReadBytes_msg_buffer == NULL)
+            {
+                printf("ERR: __wrap_CFE_SBN_Client_ReadBytes was given NULL buffer\n");
+            }
+            else
+            {
+                printf("ERR: __wrap_CFE_SBN_Client_ReadBytes was given MsgSz too large: %u\n", MsgSz);
+            }
+            result = -999999996;
+        }
     }
     else
     {
-        result = __real_CFE_SBN_CLIENT_ReadBytes(sockfd, msg_buffer, MsgSz);
+        result = __real_CFE_SBN_Client_ReadBytes(sockfd, msg_buffer, MsgSz);
     }
     
     return result;
@@ -419,9 +449,14 @@ void SBN_CLient_Wrapped_Functions_Setup(void)
 void SBN_CLient_Wrapped_Functions_Teardown(void)
 {
     /* SBN_CLient_Wrapped_Functions_Teardown resets all variables */
-    use_wrap_CFE_SBN_CLIENT_ReadBytes = FALSE;
-    wrap_CFE_SBN_CLIENT_ReadBytes_msg_buffer = NULL;
-    wrap_CFE_SBN_CLIENT_ReadBytes_return_value = INT_MIN;
+    use_wrap_ingest_app_message = FALSE;
+    wrap_ingest_app_message_was_called = FALSE;
+    wrap_ingest_app_message_call_count = 0;
+    use_wrap_CFE_SBN_Client_ReadBytes = FALSE;
+    wrap_CFE_SBN_Client_ReadBytes_msg_buffer = NULL;
+    wrap_CFE_SBN_Client_ReadBytes_return_value = INT_MIN;
+    wrap_CFE_SBN_Client_ReadBytes_was_called = FALSE;
+    wrap_CFE_SBN_Client_ReadBytes_call_count = 0;
     wrap_pthread_mutex_lock_should_be_called = FALSE;
     wrap_pthread_mutex_lock_was_called = FALSE;
     wrap_pthread_mutex_lock_return_value = 0;

--- a/unit-test/helpers/sbn_client_wrapped_functions.h
+++ b/unit-test/helpers/sbn_client_wrapped_functions.h
@@ -15,7 +15,7 @@
 
 #include "sbn_client_tests_includes.h"
 
-int __real_CFE_SBN_CLIENT_ReadBytes(int, unsigned char *, size_t);
+int __real_CFE_SBN_Client_ReadBytes(int, unsigned char *, size_t);
 int __real_pthread_cond_wait(pthread_cond_t *, pthread_mutex_t *);
 int __real_pthread_cond_timedwait(pthread_cond_t *, pthread_mutex_t *, 
   const struct timespec *);
@@ -30,8 +30,9 @@ int   __real_send_heartbeat(int);
 int32 __real_recv_msg(int32);
 void   __real_perror(const char *s);
 size_t __real_read(int fd, void* buf, size_t cnt);
+void __real_ingest_app_message(int SockFd, SBN_MsgSz_t MsgSz);
 
-int __wrap_CFE_SBN_CLIENT_ReadBytes(int, unsigned char *, size_t);
+int __wrap_CFE_SBN_Client_ReadBytes(int, unsigned char *, size_t);
 int __wrap_pthread_mutex_lock(pthread_mutex_t *);
 int __wrap_pthread_mutex_unlock(pthread_mutex_t *);
 int __wrap_pthread_cond_signal(pthread_cond_t *);
@@ -54,14 +55,20 @@ int __wrap_connect(int, const struct sockaddr *, socklen_t);
 int __wrap_connect_to_server(const char *, uint16_t);
 size_t __wrap_read(int fd, void* buf, size_t cnt); 
 unsigned int __wrap_sleep(unsigned int seconds);
+void __wrap_ingest_app_message(int SockFd, SBN_MsgSz_t MsgSz);
 
 /* functions called by function pointer */
 void wrap_sleep_set_continue_heartbeat_false(void);
 void wrap_log_message_set_continue_recv_check_false(void);
 
-extern boolean use_wrap_CFE_SBN_CLIENT_ReadBytes;
-extern unsigned char *wrap_CFE_SBN_CLIENT_ReadBytes_msg_buffer;
-extern int wrap_CFE_SBN_CLIENT_ReadBytes_return_value;
+extern boolean use_wrap_ingest_app_message;
+extern boolean wrap_ingest_app_message_was_called;
+extern int wrap_ingest_app_message_call_count;
+extern boolean use_wrap_CFE_SBN_Client_ReadBytes;
+extern unsigned char *wrap_CFE_SBN_Client_ReadBytes_msg_buffer;
+extern int wrap_CFE_SBN_Client_ReadBytes_return_value;
+extern boolean wrap_CFE_SBN_Client_ReadBytes_was_called;
+extern int wrap_CFE_SBN_Client_ReadBytes_call_count;
 extern boolean wrap_pthread_mutex_lock_should_be_called;
 extern boolean wrap_pthread_mutex_lock_was_called;
 extern int wrap_pthread_mutex_lock_return_value;

--- a/unit-test/sbn_client_ingest_tests.c
+++ b/unit-test/sbn_client_ingest_tests.c
@@ -13,12 +13,6 @@
 #include "sbn_client_tests_includes.h"
 
 
-
-void OS_Application_Startup(void)
-{
-    UtTest_Setup();
-}
-
 /*******************************************************************************
 **
 **  SBN_Client_Ingest_Tests Setup and Teardown

--- a/unit-test/sbn_client_ingest_tests.c
+++ b/unit-test/sbn_client_ingest_tests.c
@@ -12,6 +12,13 @@
 
 #include "sbn_client_tests_includes.h"
 
+
+
+void OS_Application_Startup(void)
+{
+    UtTest_Setup();
+}
+
 /*******************************************************************************
 **
 **  SBN_Client_Ingest_Tests Setup and Teardown
@@ -40,14 +47,14 @@ void Test_ingest_app_message_ReadBytesFails(void)
     /* Arrange */ 
     char err_msg[60];
     int sockfd = Any_int();
-    int msgSize = rand() % CFE_SB_MAX_SB_MSG_SIZE;
+    int msgSize = rand() % CFE_SBN_CLIENT_MAX_MESSAGE_SIZE;
     
-    use_wrap_CFE_SBN_CLIENT_ReadBytes = TRUE;
-    wrap_CFE_SBN_CLIENT_ReadBytes_return_value = Any_int32_Except(CFE_SUCCESS);
+    use_wrap_CFE_SBN_Client_ReadBytes = TRUE;
+    wrap_CFE_SBN_Client_ReadBytes_return_value = Any_int32_Except(CFE_SUCCESS);
     
     snprintf(err_msg, 60,
-      "CFE_SBN_CLIENT_ReadBytes returned a bad status = 0x%08X\n", 
-      wrap_CFE_SBN_CLIENT_ReadBytes_return_value);
+      "CFE_SBN_Client_ReadBytes returned a bad status = 0x%08X\n", 
+      wrap_CFE_SBN_Client_ReadBytes_return_value);
     
     log_message_expected_string = err_msg;
     
@@ -76,9 +83,9 @@ void Test_ingest_app_message_FailsWhenNoPipesInUse(void)
     wrap_pthread_cond_signal_should_be_called = FALSE;
     use_wrap_CFE_SBN_Client_GetMsgId = TRUE;
     wrap_CFE_SBN_Client_GetMsgId_return_value = msg[0] << 8 | msg[1];
-    use_wrap_CFE_SBN_CLIENT_ReadBytes = TRUE;
-    wrap_CFE_SBN_CLIENT_ReadBytes_return_value = CFE_SUCCESS;
-    wrap_CFE_SBN_CLIENT_ReadBytes_msg_buffer = msg;
+    use_wrap_CFE_SBN_Client_ReadBytes = TRUE;
+    wrap_CFE_SBN_Client_ReadBytes_return_value = CFE_SUCCESS;
+    wrap_CFE_SBN_Client_ReadBytes_msg_buffer = msg;
 
     log_message_expected_string = err_msg;
 
@@ -111,9 +118,9 @@ void Test_ingest_app_message_FailsOverflowWhenNumberOfMessagesIsFull(void)
     wrap_pthread_cond_signal_should_be_called = FALSE;
     use_wrap_CFE_SBN_Client_GetMsgId = TRUE;
     wrap_CFE_SBN_Client_GetMsgId_return_value = msg[0] << 8 | msg[1];
-    use_wrap_CFE_SBN_CLIENT_ReadBytes = TRUE;
-    wrap_CFE_SBN_CLIENT_ReadBytes_return_value = CFE_SUCCESS;
-    wrap_CFE_SBN_CLIENT_ReadBytes_msg_buffer = msg;
+    use_wrap_CFE_SBN_Client_ReadBytes = TRUE;
+    wrap_CFE_SBN_Client_ReadBytes_return_value = CFE_SUCCESS;
+    wrap_CFE_SBN_Client_ReadBytes_msg_buffer = msg;
     
     PipeTbl[pipe_assigned].InUse = CFE_SBN_CLIENT_IN_USE;
     PipeTbl[pipe_assigned].PipeId = pipe_assigned;
@@ -157,8 +164,8 @@ void Test_ingest_app_message_FailsWhenNoPipeLookingForMessageId(void)
     int sockfd = Any_int();
     char err_msg[60] = "SBN_CLIENT: ERROR no subscription for this msgid";
     
-    use_wrap_CFE_SBN_CLIENT_ReadBytes = TRUE;
-    wrap_CFE_SBN_CLIENT_ReadBytes_return_value = Any_int32_Except(CFE_SUCCESS);
+    use_wrap_CFE_SBN_Client_ReadBytes = TRUE;
+    wrap_CFE_SBN_Client_ReadBytes_return_value = Any_int32_Except(CFE_SUCCESS);
     
     log_message_expected_string = err_msg;
     
@@ -167,9 +174,9 @@ void Test_ingest_app_message_FailsWhenNoPipeLookingForMessageId(void)
     wrap_pthread_cond_signal_should_be_called = FALSE;
     use_wrap_CFE_SBN_Client_GetMsgId = TRUE;
     wrap_CFE_SBN_Client_GetMsgId_return_value = msg[0] << 8 | msg[1];
-    use_wrap_CFE_SBN_CLIENT_ReadBytes = TRUE;
-    wrap_CFE_SBN_CLIENT_ReadBytes_return_value = CFE_SUCCESS;
-    wrap_CFE_SBN_CLIENT_ReadBytes_msg_buffer = msg;
+    use_wrap_CFE_SBN_Client_ReadBytes = TRUE;
+    wrap_CFE_SBN_Client_ReadBytes_return_value = CFE_SUCCESS;
+    wrap_CFE_SBN_Client_ReadBytes_msg_buffer = msg;
     
     PipeTbl[pipe_assigned].InUse = CFE_SBN_CLIENT_IN_USE;
     PipeTbl[pipe_assigned].PipeId = pipe_assigned;
@@ -218,9 +225,9 @@ void Test_ingest_app_message_SuccessAllSlotsAvailable(void)
     wrap_pthread_cond_signal_should_be_called = TRUE;
     use_wrap_CFE_SBN_Client_GetMsgId = TRUE;
     wrap_CFE_SBN_Client_GetMsgId_return_value = msg[0] << 8 | msg[1];
-    use_wrap_CFE_SBN_CLIENT_ReadBytes = TRUE;
-    wrap_CFE_SBN_CLIENT_ReadBytes_return_value = CFE_SUCCESS;
-    wrap_CFE_SBN_CLIENT_ReadBytes_msg_buffer = msg;
+    use_wrap_CFE_SBN_Client_ReadBytes = TRUE;
+    wrap_CFE_SBN_Client_ReadBytes_return_value = CFE_SUCCESS;
+    wrap_CFE_SBN_Client_ReadBytes_msg_buffer = msg;
     
     PipeTbl[pipe_assigned].InUse = CFE_SBN_CLIENT_IN_USE;
     PipeTbl[pipe_assigned].PipeId = pipe_assigned;
@@ -278,9 +285,9 @@ void Test_ingest_app_message_SuccessAnyNumberOfSlotsAvailable(void)
     wrap_pthread_cond_signal_should_be_called = TRUE;
     use_wrap_CFE_SBN_Client_GetMsgId = TRUE;
     wrap_CFE_SBN_Client_GetMsgId_return_value = msg[0] << 8 | msg[1];
-    use_wrap_CFE_SBN_CLIENT_ReadBytes = TRUE;
-    wrap_CFE_SBN_CLIENT_ReadBytes_return_value = CFE_SUCCESS;
-    wrap_CFE_SBN_CLIENT_ReadBytes_msg_buffer = msg;
+    use_wrap_CFE_SBN_Client_ReadBytes = TRUE;
+    wrap_CFE_SBN_Client_ReadBytes_return_value = CFE_SUCCESS;
+    wrap_CFE_SBN_Client_ReadBytes_msg_buffer = msg;
     
     PipeTbl[pipe_assigned].InUse = CFE_SBN_CLIENT_IN_USE;
     PipeTbl[pipe_assigned].PipeId = pipe_assigned;
@@ -337,9 +344,9 @@ void Test_ingest_app_message_SuccessWhenOnlyOneSlotLeft(void)
     wrap_pthread_cond_signal_should_be_called = TRUE;
     use_wrap_CFE_SBN_Client_GetMsgId = TRUE;
     wrap_CFE_SBN_Client_GetMsgId_return_value = msg[0] << 8 | msg[1];
-    use_wrap_CFE_SBN_CLIENT_ReadBytes = TRUE;
-    wrap_CFE_SBN_CLIENT_ReadBytes_return_value = CFE_SUCCESS;
-    wrap_CFE_SBN_CLIENT_ReadBytes_msg_buffer = msg;
+    use_wrap_CFE_SBN_Client_ReadBytes = TRUE;
+    wrap_CFE_SBN_Client_ReadBytes_return_value = CFE_SUCCESS;
+    wrap_CFE_SBN_Client_ReadBytes_msg_buffer = msg;
     
     PipeTbl[pipe_assigned].InUse = CFE_SBN_CLIENT_IN_USE;
     PipeTbl[pipe_assigned].PipeId = pipe_assigned;

--- a/unit-test/sbn_client_init_tests.c
+++ b/unit-test/sbn_client_init_tests.c
@@ -13,11 +13,6 @@
 #include "sbn_client_tests_includes.h"
 
 
-
-void OS_Application_Startup(void)
-{
-    UtTest_Setup();
-}
 /*******************************************************************************
 **
 **  SBN_Client_Init_Tests Setup and Teardown

--- a/unit-test/sbn_client_init_tests.c
+++ b/unit-test/sbn_client_init_tests.c
@@ -12,6 +12,12 @@
 
 #include "sbn_client_tests_includes.h"
 
+
+
+void OS_Application_Startup(void)
+{
+    UtTest_Setup();
+}
 /*******************************************************************************
 **
 **  SBN_Client_Init_Tests Setup and Teardown

--- a/unit-test/sbn_client_logger_tests.c
+++ b/unit-test/sbn_client_logger_tests.c
@@ -13,12 +13,6 @@
 #include "sbn_client_tests_includes.h"
 
 
-
-void OS_Application_Startup(void)
-{
-    UtTest_Setup();
-}
-
 extern const char *log_message_expected_string;
 extern boolean log_message_was_called;
 extern const char *perror_expected_string;

--- a/unit-test/sbn_client_logger_tests.c
+++ b/unit-test/sbn_client_logger_tests.c
@@ -12,6 +12,13 @@
 
 #include "sbn_client_tests_includes.h"
 
+
+
+void OS_Application_Startup(void)
+{
+    UtTest_Setup();
+}
+
 extern const char *log_message_expected_string;
 extern boolean log_message_was_called;
 extern const char *perror_expected_string;

--- a/unit-test/sbn_client_minders_tests.c
+++ b/unit-test/sbn_client_minders_tests.c
@@ -14,6 +14,12 @@
 
 
 
+
+void OS_Application_Startup(void)
+{
+    UtTest_Setup();
+}
+
 /*******************************************************************************
 **
 **  SBN_Client_Minders_Tests Setup and Teardown

--- a/unit-test/sbn_client_minders_tests.c
+++ b/unit-test/sbn_client_minders_tests.c
@@ -13,13 +13,6 @@
 #include "sbn_client_tests_includes.h"
 
 
-
-
-void OS_Application_Startup(void)
-{
-    UtTest_Setup();
-}
-
 /*******************************************************************************
 **
 **  SBN_Client_Minders_Tests Setup and Teardown

--- a/unit-test/sbn_client_tests.c
+++ b/unit-test/sbn_client_tests.c
@@ -12,6 +12,11 @@
 
 #include "sbn_client_tests_includes.h"
 
+
+void OS_Application_Startup(void)
+{
+    UtTest_Setup();
+}
 /*******************************************************************************
 **
 **  SBN_Client_Tests Setup and Teardown
@@ -129,6 +134,266 @@ void Test_CFE_SBN_Client_GetAvailPipeIdx_ReturnsIndexForFirstOpenPipe(void)
 
 /* end CFE_SBN_Client_GetAvailPipeIdx Tests */
 
+
+/*******************************************************************************
+**
+**  recv_msg Tests
+**
+*******************************************************************************/
+
+void Test_recv_msg_returns_status_WhenFirst_CFE_SBN_Client_ReadBytes_DoesNotReturn_CFE_SUCCESS(void)
+{
+    /* Arrange */
+    int32 arg_sockfd = 0;
+    int32 result;
+    int32 forced_readbyte_fail = Any_int32_Except(CFE_SUCCESS);
+    unsigned char sbn_hdr_buffer[SBN_PACKED_HDR_SZ];
+
+    wrap_CFE_SBN_Client_ReadBytes_msg_buffer = sbn_hdr_buffer;
+    use_wrap_CFE_SBN_Client_ReadBytes = TRUE;
+    wrap_CFE_SBN_Client_ReadBytes_return_value = forced_readbyte_fail;
+      
+    /* Act */
+    result = recv_msg(arg_sockfd);
+    
+    /* Assert */
+    UtAssert_True(wrap_CFE_SBN_Client_ReadBytes_was_called == TRUE,
+      "CFE_SBN_Client_ReadBytes was called");
+    UtAssert_True(wrap_CFE_SBN_Client_ReadBytes_call_count == 1,
+      "CFE_SBN_Client_ReadBytes was called once");
+    UtAssert_True(result == forced_readbyte_fail,
+      "Fail result was received expectedly");
+}
+
+void Test_recv_msg_returns_CFE_EVS_ERROR_When_MsgType_IsUnrecognized(void)
+{
+    /* Arrange */
+    int32 arg_sockfd = 0;
+    int32 result;
+    int32 forced_readbyte_return = CFE_SUCCESS;
+    unsigned char sbn_hdr_buffer[SBN_PACKED_HDR_SZ];
+    int idx = 0;
+
+    /* Pack header oversize message to show never used */ 
+    sbn_hdr_buffer[idx++] = 0xFF;
+    sbn_hdr_buffer[idx++] = 0xFF;
+
+    // Pack invalid message type
+    sbn_hdr_buffer[idx++] = 0xFF;
+
+    wrap_CFE_SBN_Client_ReadBytes_msg_buffer = sbn_hdr_buffer;
+    use_wrap_CFE_SBN_Client_ReadBytes = TRUE;
+    wrap_CFE_SBN_Client_ReadBytes_return_value = forced_readbyte_return;
+      
+    /* Act */
+    result = recv_msg(arg_sockfd);
+    
+    /* Assert */
+    UtAssert_True(wrap_CFE_SBN_Client_ReadBytes_was_called == TRUE,
+      "CFE_SBN_Client_ReadBytes was called");
+    UtAssert_True(wrap_CFE_SBN_Client_ReadBytes_call_count == 1,
+      "CFE_SBN_Client_ReadBytes was called once");
+    UtAssert_True(result == CFE_EVS_ERROR,
+      "Fail MsgType result was received expectedly");
+}
+
+
+void Test_recv_msg_returns_status_From_CFE_SBN_Client_ReadBytes_When_MsgType_Is_SBN_NO_MSG(void)
+{
+    /* Arrange */
+    int32 arg_sockfd = 0;
+    int32 result;
+    int32 forced_readbyte_return = CFE_SUCCESS;
+    unsigned char sbn_hdr_buffer[CFE_SBN_CLIENT_MAX_MESSAGE_SIZE];
+    int idx = 0;
+
+    /* Pack full size message */ 
+    sbn_hdr_buffer[idx++] = 0x80;
+    sbn_hdr_buffer[idx++] = 0x00;
+
+    // Pack valid message type
+    sbn_hdr_buffer[idx++] = SBN_NO_MSG;
+
+    wrap_CFE_SBN_Client_ReadBytes_msg_buffer = sbn_hdr_buffer;
+    use_wrap_CFE_SBN_Client_ReadBytes = TRUE;
+    wrap_CFE_SBN_Client_ReadBytes_return_value = forced_readbyte_return;
+      
+    /* Act */
+    result = recv_msg(arg_sockfd);
+    
+    /* Assert */
+    UtAssert_True(wrap_CFE_SBN_Client_ReadBytes_was_called == TRUE,
+      "CFE_SBN_Client_ReadBytes was called");
+    UtAssert_True(wrap_CFE_SBN_Client_ReadBytes_call_count == 2,
+      "CFE_SBN_Client_ReadBytes was called twice");
+    UtAssert_True(result == CFE_SUCCESS,
+      "Success result was received expectedly");
+}
+
+void Test_recv_msg_returns_status_From_CFE_SBN_Client_ReadBytes_When_MsgType_Is_SBN_SUB_MSG(void)
+{
+    /* Arrange */
+    int32 arg_sockfd = 0;
+    int32 result;
+    int32 forced_readbyte_return = CFE_SUCCESS;
+    unsigned char sbn_hdr_buffer[CFE_SBN_CLIENT_MAX_MESSAGE_SIZE];
+    int idx = 0;
+
+    /* Pack full size message */ 
+    sbn_hdr_buffer[idx++] = 0x80;
+    sbn_hdr_buffer[idx++] = 0x00;
+
+    // Pack valid message type
+    sbn_hdr_buffer[idx++] = SBN_SUB_MSG;
+
+    wrap_CFE_SBN_Client_ReadBytes_msg_buffer = sbn_hdr_buffer;
+    use_wrap_CFE_SBN_Client_ReadBytes = TRUE;
+    wrap_CFE_SBN_Client_ReadBytes_return_value = forced_readbyte_return;
+      
+    /* Act */
+    result = recv_msg(arg_sockfd);
+    
+    /* Assert */
+    UtAssert_True(wrap_CFE_SBN_Client_ReadBytes_was_called == TRUE,
+      "CFE_SBN_Client_ReadBytes was called");
+    UtAssert_True(wrap_CFE_SBN_Client_ReadBytes_call_count == 2,
+      "CFE_SBN_Client_ReadBytes was called twice");
+    UtAssert_True(result == CFE_SUCCESS,
+      "Success result was received expectedly");
+}
+
+void Test_recv_msg_returns_status_From_CFE_SBN_Client_ReadBytes_When_MsgType_Is_SBN_UNSUB_MSG(void)
+{
+    /* Arrange */
+    int32 arg_sockfd = 0;
+    int32 result;
+    int32 forced_readbyte_return = CFE_SUCCESS;
+    unsigned char sbn_hdr_buffer[CFE_SBN_CLIENT_MAX_MESSAGE_SIZE];
+    int idx = 0;
+
+    /* Pack full size message */ 
+    sbn_hdr_buffer[idx++] = 0x80;
+    sbn_hdr_buffer[idx++] = 0x00;
+
+    // Pack valid message type
+    sbn_hdr_buffer[idx++] = SBN_UNSUB_MSG;
+
+    wrap_CFE_SBN_Client_ReadBytes_msg_buffer = sbn_hdr_buffer;
+    use_wrap_CFE_SBN_Client_ReadBytes = TRUE;
+    wrap_CFE_SBN_Client_ReadBytes_return_value = forced_readbyte_return;
+      
+    /* Act */
+    result = recv_msg(arg_sockfd);
+    
+    /* Assert */
+    UtAssert_True(wrap_CFE_SBN_Client_ReadBytes_was_called == TRUE,
+      "CFE_SBN_Client_ReadBytes was called");
+    UtAssert_True(wrap_CFE_SBN_Client_ReadBytes_call_count == 2,
+      "CFE_SBN_Client_ReadBytes was called twice");
+    UtAssert_True(result == CFE_SUCCESS,
+      "Success result was received expectedly");
+}
+
+void Test_recv_msg_returns_status_From_CFE_SBN_Client_ReadBytes_When_MsgType_Is_SBN_PROTO_MSG(void)
+{
+    /* Arrange */
+    int32 arg_sockfd = 0;
+    int32 result;
+    int32 forced_readbyte_return = CFE_SUCCESS;
+    unsigned char sbn_hdr_buffer[CFE_SBN_CLIENT_MAX_MESSAGE_SIZE];
+    int idx = 0;
+
+    /* Pack full size message */ 
+    sbn_hdr_buffer[idx++] = 0x80;
+    sbn_hdr_buffer[idx++] = 0x00;
+
+    // Pack valid message type
+    sbn_hdr_buffer[idx++] = SBN_PROTO_MSG;
+
+    wrap_CFE_SBN_Client_ReadBytes_msg_buffer = sbn_hdr_buffer;
+    use_wrap_CFE_SBN_Client_ReadBytes = TRUE;
+    wrap_CFE_SBN_Client_ReadBytes_return_value = forced_readbyte_return;
+      
+    /* Act */
+    result = recv_msg(arg_sockfd);
+    
+    /* Assert */
+    UtAssert_True(wrap_CFE_SBN_Client_ReadBytes_was_called == TRUE,
+      "CFE_SBN_Client_ReadBytes was called");
+    UtAssert_True(wrap_CFE_SBN_Client_ReadBytes_call_count == 2,
+      "CFE_SBN_Client_ReadBytes was called twice");
+    UtAssert_True(result == CFE_SUCCESS,
+      "Success result was received expectedly");
+}
+
+void Test_recv_msg_returns_status_From_CFE_SBN_Client_ReadBytes_When_MsgType_Is_SBN_HEARTBEAT_MSG(void)
+{
+    /* Arrange */
+    int32 arg_sockfd = 0;
+    int32 result;
+    int32 forced_readbyte_return = CFE_SUCCESS;
+    unsigned char sbn_hdr_buffer[CFE_SBN_CLIENT_MAX_MESSAGE_SIZE];
+    int idx = 0;
+
+    /* Pack full size message */ 
+    sbn_hdr_buffer[idx++] = 0x80;
+    sbn_hdr_buffer[idx++] = 0x00;
+
+    // Pack valid message type
+    sbn_hdr_buffer[idx++] = SBN_HEARTBEAT_MSG;
+
+    wrap_CFE_SBN_Client_ReadBytes_msg_buffer = sbn_hdr_buffer;
+    use_wrap_CFE_SBN_Client_ReadBytes = TRUE;
+    wrap_CFE_SBN_Client_ReadBytes_return_value = forced_readbyte_return;
+      
+    /* Act */
+    result = recv_msg(arg_sockfd);
+    
+    /* Assert */
+    UtAssert_True(wrap_CFE_SBN_Client_ReadBytes_was_called == TRUE,
+      "CFE_SBN_Client_ReadBytes was called");
+    UtAssert_True(wrap_CFE_SBN_Client_ReadBytes_call_count == 2,
+      "CFE_SBN_Client_ReadBytes was called twice");
+    UtAssert_True(result == CFE_SUCCESS,
+      "Success result was received expectedly");
+}
+
+void Test_recv_msg_returns_Calls_ingest_app_message_AndReturns_CFE_SUCCESS_When_MsgType_Is_SBN_APP_MSG(void)
+{
+    /* Arrange */
+    int32 arg_sockfd = 0;
+    int32 result;
+    int32 forced_readbyte_return = CFE_SUCCESS;
+    unsigned char sbn_hdr_buffer[CFE_SBN_CLIENT_MAX_MESSAGE_SIZE];
+    int idx = 0;
+
+    /* Pack full size message */ 
+    sbn_hdr_buffer[idx++] = 0x80;
+    sbn_hdr_buffer[idx++] = 0x00;
+
+    // Pack valid message type
+    sbn_hdr_buffer[idx++] = SBN_APP_MSG;
+
+    wrap_CFE_SBN_Client_ReadBytes_msg_buffer = sbn_hdr_buffer;
+    use_wrap_CFE_SBN_Client_ReadBytes = TRUE;
+    wrap_CFE_SBN_Client_ReadBytes_return_value = forced_readbyte_return;
+    use_wrap_ingest_app_message = TRUE;
+      
+    /* Act */
+    result = recv_msg(arg_sockfd);
+    
+    /* Assert */
+    UtAssert_True(wrap_CFE_SBN_Client_ReadBytes_was_called == TRUE,
+      "CFE_SBN_Client_ReadBytes was called");
+    UtAssert_True(wrap_CFE_SBN_Client_ReadBytes_call_count == 1,
+      "CFE_SBN_Client_ReadBytes was called once");
+    UtAssert_True(wrap_ingest_app_message_was_called == TRUE,
+      "ingest_app_messagewas called");
+    UtAssert_True(wrap_ingest_app_message_call_count == 1,
+      "ingest_app_message was called once");
+    UtAssert_True(result == CFE_SUCCESS,
+      "Success result was received expectedly");
+}
 /*******************************************************************************
 **
 **  add test group functions
@@ -152,6 +417,34 @@ void add_CFE_SBN_Client_GetAvailPipeIdx(void)
       "Test_CFE_SBN_Client_GetAvailPipeIdx_ReturnsIndexForFirstOpenPipe");
 } /* end add_CFE_SBN_Client_GetAvailPipeIdx */
 
+void add_recv_msg(void)
+{
+    UtTest_Add(Test_recv_msg_returns_status_WhenFirst_CFE_SBN_Client_ReadBytes_DoesNotReturn_CFE_SUCCESS, 
+      SBN_Client_Tests_Setup, SBN_Client_Tests_Teardown, 
+      "Test_recv_msg_returns_status_WhenFirst_CFE_SBN_Client_ReadBytes_DoesNotReturn_CFE_SUCCESS");
+    UtTest_Add(Test_recv_msg_returns_CFE_EVS_ERROR_When_MsgType_IsUnrecognized, 
+      SBN_Client_Tests_Setup, SBN_Client_Tests_Teardown, 
+      "Test_recv_msg_returns_CFE_EVS_ERROR_When_MsgType_IsUnrecognized");
+    UtTest_Add(Test_recv_msg_returns_status_From_CFE_SBN_Client_ReadBytes_When_MsgType_Is_SBN_NO_MSG, 
+      SBN_Client_Tests_Setup, SBN_Client_Tests_Teardown, 
+      "Test_recv_msg_returns_status_From_CFE_SBN_Client_ReadBytes_When_MsgType_Is_SBN_NO_MSG");
+    UtTest_Add(Test_recv_msg_returns_status_From_CFE_SBN_Client_ReadBytes_When_MsgType_Is_SBN_SUB_MSG, 
+      SBN_Client_Tests_Setup, SBN_Client_Tests_Teardown, 
+      "Test_recv_msg_returns_status_From_CFE_SBN_Client_ReadBytes_When_MsgType_Is_SBN_SUB_MSG");
+    UtTest_Add(Test_recv_msg_returns_status_From_CFE_SBN_Client_ReadBytes_When_MsgType_Is_SBN_UNSUB_MSG, 
+      SBN_Client_Tests_Setup, SBN_Client_Tests_Teardown, 
+      "Test_recv_msg_returns_status_From_CFE_SBN_Client_ReadBytes_When_MsgType_Is_SBN_UNSUB_MSG");
+    UtTest_Add(Test_recv_msg_returns_status_From_CFE_SBN_Client_ReadBytes_When_MsgType_Is_SBN_PROTO_MSG, 
+      SBN_Client_Tests_Setup, SBN_Client_Tests_Teardown, 
+      "Test_recv_msg_returns_status_From_CFE_SBN_Client_ReadBytes_When_MsgType_Is_SBN_PROTO_MSG");
+    UtTest_Add(Test_recv_msg_returns_status_From_CFE_SBN_Client_ReadBytes_When_MsgType_Is_SBN_HEARTBEAT_MSG, 
+      SBN_Client_Tests_Setup, SBN_Client_Tests_Teardown, 
+      "Test_recv_msg_returns_status_From_CFE_SBN_Client_ReadBytes_When_MsgType_Is_SBN_HEARTBEAT_MSG");
+    UtTest_Add(Test_recv_msg_returns_Calls_ingest_app_message_AndReturns_CFE_SUCCESS_When_MsgType_Is_SBN_APP_MSG, 
+      SBN_Client_Tests_Setup, SBN_Client_Tests_Teardown, 
+      "Test_recv_msg_returns_Calls_ingest_app_message_AndReturns_CFE_SUCCESS_When_MsgType_Is_SBN_APP_MSG");
+} /* end add_recv_msg */
+
 /* end add test group functions */
 
 /*******************************************************************************
@@ -165,6 +458,8 @@ void UtTest_Setup(void)
     add_CFE_SBN_Client_InitPipeTbl_tests();
     
     add_CFE_SBN_Client_GetAvailPipeIdx();
+
+    add_recv_msg();
 } /* end UtTest_Setup */
 
 /* end Required UtTest_Setup function for ut-assert framework */

--- a/unit-test/sbn_client_tests.c
+++ b/unit-test/sbn_client_tests.c
@@ -12,11 +12,6 @@
 
 #include "sbn_client_tests_includes.h"
 
-
-void OS_Application_Startup(void)
-{
-    UtTest_Setup();
-}
 /*******************************************************************************
 **
 **  SBN_Client_Tests Setup and Teardown

--- a/unit-test/sbn_client_utils_tests.c
+++ b/unit-test/sbn_client_utils_tests.c
@@ -14,6 +14,11 @@
 
 void add_connect_to_server_tests(void);
 
+void OS_Application_Startup(void)
+{
+    UtTest_Setup();
+}
+
 /*******************************************************************************
 **
 **  SBN_Client_Utils_Tests Setup and Teardown
@@ -446,9 +451,29 @@ void Test_CFE_SBN_Client_GetPipeIdxSuccessPipeIdDoesNotEqualPipeIdx(void)
 /* end CFE_SBN_Client_GetPipeIdx Tests */
 
 
+/*******************************************************************************
+**
+**  CFE_SBN_Client_ReadBytes Tests
+**
+*******************************************************************************/
 
-/* CFE_SBN_CLIENT_ReadBytes Tests*/
-void Test_CFE_SBN_CLIENT_ReadBytes_ReturnsErrorWhenPipeBroken(void)
+void Test_CFE_SBN_Client_ReadBytes_ReturnsFailWhen_MsgSz_IsLargerThan_CFE_SBN_CLIENT_MAX_MESSAGE_SIZE(void)
+{
+    /* Arrange */
+    int sock_fd = (rand() % 10) + 1; /* 1 to 10 */
+    size_t MsgSz = CFE_SBN_CLIENT_MAX_MESSAGE_SIZE + 1;
+    unsigned char msg_buffer[CFE_SBN_CLIENT_MAX_MESSAGE_SIZE];
+    int result;
+    
+    /* Act */ 
+    result = CFE_SBN_Client_ReadBytes(sock_fd, msg_buffer, MsgSz);
+    
+    /* Assert */
+    UtAssert_True(result == CFE_SBN_CLIENT_BAD_ARGUMENT, 
+      "MsgSz given was larger than CFE_SBN_CLIENT_MAX_MESSAGE_SIZE");
+} /* end Test_CFE_SBN_Client_ReadBytes_ReturnsErrorWhenPipeBroken */
+
+void Test_CFE_SBN_Client_ReadBytes_ReturnsErrorWhenPipeBroken(void)
 {
     /* Arrange */
     int sock_fd = (rand() % 10) + 1; /* 1 to 10 */
@@ -458,14 +483,14 @@ void Test_CFE_SBN_CLIENT_ReadBytes_ReturnsErrorWhenPipeBroken(void)
     int result;
     
     /* Act */ 
-    result = CFE_SBN_CLIENT_ReadBytes(sock_fd, msg_buffer, MsgSz);
+    result = CFE_SBN_Client_ReadBytes(sock_fd, msg_buffer, MsgSz);
     
     /* Assert */
     UtAssert_True(result == CFE_SBN_CLIENT_PIPE_BROKEN_ERR, 
-      "CFE_SBN_CLIENT_ReadBytes should return CFE_SBN_CLIENT_PIPE_BROKEN_ERR");
-} /* end Test_CFE_SBN_CLIENT_ReadBytes_ReturnsErrorWhenPipeBroken */
+      "CFE_SBN_Client_ReadBytes should return CFE_SBN_CLIENT_PIPE_BROKEN_ERR");
+} /* end Test_CFE_SBN_Client_ReadBytes_ReturnsErrorWhenPipeBroken */
 
-void Test_CFE_SBN_CLIENT_ReadBytes_ReturnsErrorWhenPipeClosed(void)
+void Test_CFE_SBN_Client_ReadBytes_ReturnsErrorWhenPipeClosed(void)
 {
     /* Arrange */
     int sock_fd = (rand() % 10) + 1; /* 1 to 10 */
@@ -475,14 +500,14 @@ void Test_CFE_SBN_CLIENT_ReadBytes_ReturnsErrorWhenPipeClosed(void)
     int result;
     
     /* Act */ 
-    result = CFE_SBN_CLIENT_ReadBytes(sock_fd, msg_buffer, MsgSz);
+    result = CFE_SBN_Client_ReadBytes(sock_fd, msg_buffer, MsgSz);
     
     /* Assert */
     UtAssert_True(result == CFE_SBN_CLIENT_PIPE_CLOSED_ERR, 
-        "CFE_SBN_CLIENT_ReadBytes returned CFE_SBN_CLIENT_PIPE_CLOSED_ERR");
+        "CFE_SBN_Client_ReadBytes returned CFE_SBN_CLIENT_PIPE_CLOSED_ERR");
 }
 
-void Test_CFE_SBN_CLIENT_ReadBytes_ReturnsCfeSuccessWhenAllBytesReceived(void)
+void Test_CFE_SBN_Client_ReadBytes_ReturnsCfeSuccessWhenAllBytesReceived(void)
 {
     /* Arrange */
     int sock_fd = (rand() % 10) + 1; /* 1 to 10 */
@@ -492,13 +517,13 @@ void Test_CFE_SBN_CLIENT_ReadBytes_ReturnsCfeSuccessWhenAllBytesReceived(void)
     int result;
     
     /* Act */ 
-    result = CFE_SBN_CLIENT_ReadBytes(sock_fd, msg_buffer, MsgSz);
+    result = CFE_SBN_Client_ReadBytes(sock_fd, msg_buffer, MsgSz);
     
     /* Assert */
     UtAssert_True(result == CFE_SUCCESS, 
-        "CFE_SBN_CLIENT_ReadBytes returned CFE_SUCCESS");
+        "CFE_SBN_Client_ReadBytes returned CFE_SUCCESS");
 }
-/* end CFE_SBN_CLIENT_ReadBytes Tests*/
+/* end CFE_SBN_Client_ReadBytes Tests*/
 
 /*************************************************/
 
@@ -568,19 +593,23 @@ void UtTest_Setup(void)
       SBN_Client_Utils_Tests_Setup, SBN_Client_Utils_Tests_Teardown, 
       "Test_CFE_SBN_Client_GetPipeIdxSuccessPipeIdDoesNotEqualPipeIdx");
     
-    /* CFE_SBN_CLIENT_ReadBytes Tests*/
+    /* CFE_SBN_Client_ReadBytes Tests*/
     UtTest_Add(
-      Test_CFE_SBN_CLIENT_ReadBytes_ReturnsErrorWhenPipeBroken, 
+      Test_CFE_SBN_Client_ReadBytes_ReturnsErrorWhenPipeBroken, 
       SBN_Client_Utils_Tests_Setup, SBN_Client_Utils_Tests_Teardown, 
-      "Test_CFE_SBN_CLIENT_ReadBytes_ReturnsErrorWhenPipeBroken");
+      "Test_CFE_SBN_Client_ReadBytes_ReturnsErrorWhenPipeBroken");
     UtTest_Add(
-      Test_CFE_SBN_CLIENT_ReadBytes_ReturnsErrorWhenPipeClosed, 
+      Test_CFE_SBN_Client_ReadBytes_ReturnsErrorWhenPipeClosed, 
       SBN_Client_Utils_Tests_Setup, SBN_Client_Utils_Tests_Teardown, 
-      "Test_CFE_SBN_CLIENT_ReadBytes_ReturnsErrorWhenPipeClosed");
+      "Test_CFE_SBN_Client_ReadBytes_ReturnsErrorWhenPipeClosed");
     UtTest_Add(
-      Test_CFE_SBN_CLIENT_ReadBytes_ReturnsCfeSuccessWhenAllBytesReceived, 
+      Test_CFE_SBN_Client_ReadBytes_ReturnsCfeSuccessWhenAllBytesReceived, 
       SBN_Client_Utils_Tests_Setup, SBN_Client_Utils_Tests_Teardown, 
-      "Test_CFE_SBN_CLIENT_ReadBytes_ReturnsCfeSuccessWhenAllBytesReceived");
+      "Test_CFE_SBN_Client_ReadBytes_ReturnsCfeSuccessWhenAllBytesReceived");
+    UtTest_Add(
+      Test_CFE_SBN_Client_ReadBytes_ReturnsFailWhen_MsgSz_IsLargerThan_CFE_SBN_CLIENT_MAX_MESSAGE_SIZE, 
+      SBN_Client_Utils_Tests_Setup, SBN_Client_Utils_Tests_Teardown, 
+      "Test_CFE_SBN_Client_ReadBytes_ReturnsFailWhen_MsgSz_IsLargerThan_CFE_SBN_CLIENT_MAX_MESSAGE_SIZE");
 
 }
 

--- a/unit-test/sbn_client_utils_tests.c
+++ b/unit-test/sbn_client_utils_tests.c
@@ -14,11 +14,6 @@
 
 void add_connect_to_server_tests(void);
 
-void OS_Application_Startup(void)
-{
-    UtTest_Setup();
-}
-
 /*******************************************************************************
 **
 **  SBN_Client_Utils_Tests Setup and Teardown

--- a/unit-test/sbn_client_wrappers_tests.c
+++ b/unit-test/sbn_client_wrappers_tests.c
@@ -12,6 +12,13 @@
 
 #include "sbn_client_tests_includes.h"
 
+
+
+void OS_Application_Startup(void)
+{
+    UtTest_Setup();
+}
+
 CFE_SB_PipeId_t pipePtr;
 uint16 pipe_depth = 5;
 const char *pipeName = "TestPipe";

--- a/unit-test/sbn_client_wrappers_tests.c
+++ b/unit-test/sbn_client_wrappers_tests.c
@@ -13,12 +13,6 @@
 #include "sbn_client_tests_includes.h"
 
 
-
-void OS_Application_Startup(void)
-{
-    UtTest_Setup();
-}
-
 CFE_SB_PipeId_t pipePtr;
 uint16 pipe_depth = 5;
 const char *pipeName = "TestPipe";

--- a/unit-test/stubs/sbn_client_logger_stubs.c
+++ b/unit-test/stubs/sbn_client_logger_stubs.c
@@ -35,12 +35,12 @@ int32 log_message(const char *format, ...)
     // {
     //     (*wrap_log_message_call_func)();
     // }
-    int result;
+    int result = 0;
     int i = 0;
     int num_vars = 0;
     va_list vl;
     
-    UT_Stub_CopyToLocal(UT_KEY(log_message), format, sizeof(format));
+    UT_Stub_CopyToLocal(UT_KEY(log_message), (void *) format, sizeof(format));
     
     va_start(vl, format);
     while (format[i] && format[i+1])


### PR DESCRIPTION
Fixes to ensure `MsgSz` > `CFE_SBN_CLIENT_MAX_MESSAGE_SIZE` (`CFE_SB_MAX_SB_MSG_SIZE`) are denied.
Check was put into `CFE_SBN_Client_ReadBytes` so that both callers benefited from the same fix.

- `CFE_SBN_CLIENT_ReadBytes` -> `CFE_SBN_Client_ReadBytes`
  -  this follows naming convention of functions
- Now checks MsgSz to ensure not greater than max size allowed
  -  unit test wrapper also ensures this behavior to avoid segfault
- `recv_msg`
  -   fixed space in a print out
  -   consolidated switch cases that all performed same action
  -   no change in behavior verified by tests
- Updated unit tests for new code and more robust coverage
- Now using `CFE_SBN_CLIENT_MAX_MESSAGE_SIZE` instead of `CFE_SB_MAX_SB_MSG_SIZE`
  -   already defined as that value and should have been used initially